### PR TITLE
Compatibility fixes for python 2.7

### DIFF
--- a/serial/rfc2217.py
+++ b/serial/rfc2217.py
@@ -64,8 +64,12 @@ import time
 import struct
 import socket
 import threading
-import queue
 import logging
+
+try:
+    import queue
+except ImportError:
+    import Queue as queue
 
 # port string is expected to be something like this:
 # rfc2217://host:port

--- a/serial/serialposix.py
+++ b/serial/serialposix.py
@@ -298,7 +298,7 @@ def acquireLock(port, path, secondTry = False):
     else:
         try:
             fhLock = os.open(path, os.O_EXCL|os.O_CREAT|os.O_RDWR)
-            pid = bytes(str(os.getpid()) + "\n", encoding='UTF-8')
+            pid = (str(os.getpid()) + "\n").encode('UTF-8')
             os.write(fhLock,pid)
             os.close(fhLock)
             return True

--- a/serial/serialutil.py
+++ b/serial/serialutil.py
@@ -135,6 +135,9 @@ class FileLike(object):
         if not line: raise StopIteration
         return line
 
+    # Python 2 compatibility
+    next = __next__
+
     def __iter__(self):
         return self
 


### PR DESCRIPTION
After reviewing all of the changes within the serial directory between the
3.8 release and the current commit, I think this is all that is necessary
to maintain compatibility with 2.7.  Almost all of the changes for python
3 compatibility were changing the except syntax, with the old style syntax
only being necessary to support _really_ old python versions.
